### PR TITLE
Fix error Pandas 1.3.4

### DIFF
--- a/export.py
+++ b/export.py
@@ -29,7 +29,7 @@ def health_xml_to_feather(zip_file, output_file, remove_zip=False):
             df[k] = pd.to_numeric(df[k], errors="coerce")
             df = df[df["value"].notnull()]
 
-        df.reset_index().to_feather(output_file)
+        df.reset_index(drop=True).to_feather(output_file)
 
     if remove_zip:
         os.remove(zip_file)

--- a/export.py
+++ b/export.py
@@ -29,6 +29,8 @@ def health_xml_to_feather(zip_file, output_file, remove_zip=False):
             df[k] = pd.to_numeric(df[k], errors="coerce")
             df = df[df["value"].notnull()]
 
+        # Feature requires DFs to have a default index, so reset index which
+        # may have become non-contiguous after above cleanup
         df.reset_index(drop=True).to_feather(output_file)
 
     if remove_zip:

--- a/export.py
+++ b/export.py
@@ -29,7 +29,7 @@ def health_xml_to_feather(zip_file, output_file, remove_zip=False):
             df[k] = pd.to_numeric(df[k], errors="coerce")
             df = df[df["value"].notnull()]
 
-        df.to_feather(output_file)
+        df.reset_index().to_feather(output_file)
 
     if remove_zip:
         os.remove(zip_file)


### PR DESCRIPTION
Fix the error : "ValueError: feather does not support serializing a non-default index for the index; you can .reset_index() to make the index into column(s)" obtained with pandas 1.3.4.

The update removes the index before saving the dataframe.
