### PR TITLE
Allow XML file name to be specified

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,7 +47,18 @@ install.packages("feather")
 
 ```bash
 $ python export.py ~/Dropbox/export.zip ~/Downloads/data.feather
+
+# Specify XML file name in case zip file has been renamed
+$ python export.py ~/Dropbox/export_renamed.zip ~/Downloads/data.feather --xml_file_name export.zip
 ```
+
+> The export zip file contains an XML file containing
+> actual data. By default, this name can be inferred
+> from the stem of the zip file name (for example
+> `export.zip` will contain a file named `export.xml`).
+> However, if the zip file has been renamed, you may
+> need to explicitly provide the name of the XML file
+> with the `--xml_file_name` option.
 
 3. Now you can load the data in either R or Python.
 

--- a/export.py
+++ b/export.py
@@ -12,13 +12,22 @@ OTHER_KEYS = ["type", "sourceName", "unit"]
 ALL_KEYS = OTHER_KEYS + DATETIME_KEYS + NUMERIC_KEYS
 
 
-def health_xml_to_feather(zip_file, output_file, remove_zip=False):
+def health_xml_to_feather(zip_file, output_file, remove_zip=False,
+                          xml_file_name=None):
     with tempfile.TemporaryDirectory() as tmpdirname:
         f = zipfile.ZipFile(zip_file, "r")
         f.extractall(tmpdirname)
-        # Use stem to get export.xml file name in localized versions of Apple Health
-        zf_path = Path(zip_file)
-        xml_path = Path(tmpdirname) / Path("apple_health_export") / Path(f"{zf_path.stem}.xml")
+        if xml_file_name is None:
+            # Use stem to get export.xml file name in localized versions of Apple Health
+            zf_path = Path(zip_file)
+            xml_file_name = Path(f"{zf_path.stem}.xml")
+
+        xml_path = Path(tmpdirname) / Path("apple_health_export") / Path(xml_file_name)
+        if not xml_path.exists():
+            raise FileNotFoundError(
+                "XML file not found and could not be inferred from zip file name. " +
+                "Please specify file name with --xml_file_name option."
+            )
         tree = etree.parse(str(xml_path))
         records = tree.xpath("//Record")
         df = pd.DataFrame([{key: r.get(key) for key in ALL_KEYS}
@@ -46,5 +55,9 @@ if __name__ == "__main__":
     parser.add_argument("output_file", help="path to output file")
     parser.add_argument("--remove_zip", dest="remove_zip", action="store_true",
                         help="delete zip after extraction (default: false)")
+    parser.add_argument("--xml_file_name",
+                        help="name of xml file within export.zip - by default," +
+                        " inferred from zip file name stem")
     args = parser.parse_args()
-    health_xml_to_feather(args.input_file, args.output_file, args.remove_zip)
+    health_xml_to_feather(args.input_file, args.output_file,
+                          args.remove_zip, args.xml_file_name)


### PR DESCRIPTION
Follow up to #7. By default, the file name of the export XML file will be inferred from the zip file stem. However, in some cases this may need to be explicitly specified; such as if the zip file was renamed.